### PR TITLE
Vec 440 ct test chart

### DIFF
--- a/.github/workflows/build-chart-jfrog.yaml
+++ b/.github/workflows/build-chart-jfrog.yaml
@@ -1,4 +1,7 @@
 name: Build and Bundle Jfrog Helm chart
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,115 +56,33 @@ jobs:
           kubectl --namespace aerospike create secret generic aerospike-secret \
           --from-literal=features.conf="$(echo "${{ secrets.FEATURES_CONF }}")"
           
-          kubectl apply -f - <<-EOF
-            apiVersion: asdb.aerospike.com/v1
-            kind: AerospikeCluster
-            metadata:
-              name: aerospike-cluster
-              namespace: aerospike
-            spec:
-              size: 1
-              image: aerospike/aerospike-server-enterprise:7.0.0.5
-              podSpec:
-                multiPodPerHost: true
-              storage:
-                filesystemVolumePolicy:
-                  cascadeDelete: true
-                  initMethod: deleteFiles
-                volumes:
-                  - name: workdir
-                    source:
-                      persistentVolume:
-                        storageClass: standard
-                        volumeMode: Filesystem
-                        size: 3Gi
-                    aerospike:
-                      path: /opt/aerospike
-                  - name: nsvol1
-                    aerospike:
-                      path: /mnt/disks/test
-                    source:
-                      persistentVolume:
-                        storageClass: standard
-                        volumeMode: Filesystem
-                        size: 16G
-                  - name: nsvol2
-                    aerospike:
-                      path: /mnt/disks/avs-index
-                    source:
-                      persistentVolume:
-                        storageClass: standard
-                        volumeMode: Filesystem
-                        size: 16G
-                  - name: nsvol3
-                    aerospike:
-                      path: /mnt/disks/avs-data
-                    source:
-                      persistentVolume:
-                        storageClass: standard
-                        volumeMode: Filesystem
-                        size: 16G
-                  - name: nsvol4
-                    aerospike:
-                      path: /mnt/disks/avs-meta
-                    source:
-                      persistentVolume:
-                        storageClass: standard
-                        volumeMode: Filesystem
-                        size: 16G
-                  - name: aerospike-config-secret
-                    source:
-                      secret:
-                        secretName: aerospike-secret
-                    aerospike:
-                      path: /etc/aerospike/secret
-              aerospikeConfig:
-                service:
-                  feature-key-file: /etc/aerospike/secret/features.conf
-                #    security: {}
-                network:
-                  service:
-                    port: 3000
-                  fabric:
-                    port: 3001
-                  heartbeat:
-                    port: 3002
-                namespaces:
-                  - name: test
-                    replication-factor: 2
-                    storage-engine:
-                      type: device
-                      filesize: 17179869184
-                      files:
-                        - /mnt/disks/test/test.dat
-                  - name: avs-index
-                    replication-factor: 2
-                    storage-engine:
-                      type: device
-                      filesize: 17179869184
-                      files:
-                        - /mnt/disks/avs-index/avs-index.dat
-                  - name: avs-data
-                    replication-factor: 2
-                    storage-engine:
-                      type: device
-                      filesize: 17179869184
-                      files:
-                        - /mnt/disks/avs-data/avs-data.dat
-                  - name: avs-meta
-                    nsup-period: 600
-                    nsup-threads: 2
-                    evict-tenths-pct: 5
-                    replication-factor: 2
-                    storage-engine:
-                      type: device
-                      filesize: 17179869184
-                      files:
-                        - /mnt/disks/avs-meta/avs-meta.dat
-          EOF
+          kubectl apply -f ci/aerospike.yaml --wait
+
       - name: Setup avs prerequisites
         run: |
-        
+          echo "Deploy MetalLB"
+          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.4/config/manifests/metallb-native.yaml
+          kubectl wait --namespace metallb-system \
+                          --for=condition=ready pod \
+                          --selector=app=metallb \
+                          --timeout=90s
+          kubectl apply -f "charts/aerospike-vector-search/kind/config/metallb-config.yaml"
+
+
+          echo "Deploying Istio"
+          helm repo add istio https://istio-release.storage.googleapis.com/charts
+          helm repo update
+          helm install istio-base istio/base --namespace istio-system --set defaultRevision=default --create-namespace --wait
+          helm install istiod istio/istiod --namespace istio-system --create-namespace --wait
+          helm install istio-ingress istio/gateway \
+          --values "charts/aerospike-vector-search/kind/config/istio-ingressgateway-values.yaml" \
+          --namespace istio-ingress \
+          --create-namespace \
+          --wait
+
+          kubectl apply -f "charts/aerospike-vector-search/kind/config/gateway.yaml" --wait
+          kubectl apply -f "charts/aerospike-vector-search/kind/config/virtual-service-vector-search.yaml" --wait
+
       - name: Run chart-testing (install)
         run: |
           cd chart/aerospike-vector-search

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,170 @@
+name: Lint
+permissions:
+  contents: read
+  pull-requests: write
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814
+        with:
+          version: latest
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992
+
+      - name: Create kind cluster
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde
+
+      - name: Setup Prerequisites
+        run: |
+          
+          echo "Deploying AKO"
+          curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.30.0/install.sh \
+          | bash -s v0.30.0
+          
+          kubectl create -f https://operatorhub.io/install/aerospike-kubernetes-operator.yaml
+          echo "Waiting for AKO"
+          while true; do
+            if kubectl --namespace operators get deployment/aerospike-operator-controller-manager &> /dev/null; then
+              kubectl --namespace operators wait \
+                --for=condition=available --timeout=180s deployment/aerospike-operator-controller-manager
+              break
+            fi
+          done
+          
+          echo "Grant permissions to the target namespace"
+          kubectl create namespace aerospike
+          kubectl --namespace aerospike create serviceaccount aerospike-operator-controller-manager
+          kubectl create clusterrolebinding aerospike-cluster \
+            --clusterrole=aerospike-cluster --serviceaccount=aerospike:aerospike-operator-controller-manager
+          
+          echo "Set Secrets for Aerospike Cluster"
+          kubectl --namespace aerospike create secret generic aerospike-secret \
+          --from-literal=features.conf="$(echo "${{ secrets.FEATURES_CONF }}")"
+          
+          kubectl apply -f - <<-EOF
+            apiVersion: asdb.aerospike.com/v1
+            kind: AerospikeCluster
+            metadata:
+              name: aerospike-cluster
+              namespace: aerospike
+            spec:
+              size: 1
+              image: aerospike/aerospike-server-enterprise:7.0.0.5
+              podSpec:
+                multiPodPerHost: true
+              storage:
+                filesystemVolumePolicy:
+                  cascadeDelete: true
+                  initMethod: deleteFiles
+                volumes:
+                  - name: workdir
+                    source:
+                      persistentVolume:
+                        storageClass: standard
+                        volumeMode: Filesystem
+                        size: 3Gi
+                    aerospike:
+                      path: /opt/aerospike
+                  - name: nsvol1
+                    aerospike:
+                      path: /mnt/disks/test
+                    source:
+                      persistentVolume:
+                        storageClass: standard
+                        volumeMode: Filesystem
+                        size: 16G
+                  - name: nsvol2
+                    aerospike:
+                      path: /mnt/disks/avs-index
+                    source:
+                      persistentVolume:
+                        storageClass: standard
+                        volumeMode: Filesystem
+                        size: 16G
+                  - name: nsvol3
+                    aerospike:
+                      path: /mnt/disks/avs-data
+                    source:
+                      persistentVolume:
+                        storageClass: standard
+                        volumeMode: Filesystem
+                        size: 16G
+                  - name: nsvol4
+                    aerospike:
+                      path: /mnt/disks/avs-meta
+                    source:
+                      persistentVolume:
+                        storageClass: standard
+                        volumeMode: Filesystem
+                        size: 16G
+                  - name: aerospike-config-secret
+                    source:
+                      secret:
+                        secretName: aerospike-secret
+                    aerospike:
+                      path: /etc/aerospike/secret
+              aerospikeConfig:
+                service:
+                  feature-key-file: /etc/aerospike/secret/features.conf
+                #    security: {}
+                network:
+                  service:
+                    port: 3000
+                  fabric:
+                    port: 3001
+                  heartbeat:
+                    port: 3002
+                namespaces:
+                  - name: test
+                    replication-factor: 2
+                    storage-engine:
+                      type: device
+                      filesize: 17179869184
+                      files:
+                        - /mnt/disks/test/test.dat
+                  - name: avs-index
+                    replication-factor: 2
+                    storage-engine:
+                      type: device
+                      filesize: 17179869184
+                      files:
+                        - /mnt/disks/avs-index/avs-index.dat
+                  - name: avs-data
+                    replication-factor: 2
+                    storage-engine:
+                      type: device
+                      filesize: 17179869184
+                      files:
+                        - /mnt/disks/avs-data/avs-data.dat
+                  - name: avs-meta
+                    nsup-period: 600
+                    nsup-threads: 2
+                    evict-tenths-pct: 5
+                    replication-factor: 2
+                    storage-engine:
+                      type: device
+                      filesize: 17179869184
+                      files:
+                        - /mnt/disks/avs-meta/avs-meta.dat
+          EOF
+
+      - name: Run chart-testing (install)
+        run: |
+          cd chart/aerospike-vector-search
+          ct install --namespace aerospike  \
+            --target-branch ${{ github.event.repository.default_branch }} 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Test
 permissions:
   contents: read
   pull-requests: write
@@ -162,7 +162,9 @@ jobs:
                       files:
                         - /mnt/disks/avs-meta/avs-meta.dat
           EOF
-
+      - name: Setup avs prerequisites
+        run: |
+        
       - name: Run chart-testing (install)
         run: |
           cd chart/aerospike-vector-search

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Test Chart Install and tests
 permissions:
   contents: read
   pull-requests: write
@@ -7,7 +7,7 @@ env:
   WORKSPACE: "$(git rev-parse --show-toplevel)"
 
 jobs:
-  lint:
+  test-chart:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,4 +88,5 @@ jobs:
       - name: Run chart-testing (install)
         run: |
           ct install --namespace aerospike  \
-            --target-branch ${{ github.event.repository.default_branch }} 
+            --target-branch ${{ github.event.repository.default_branch }} --debug
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,8 @@ permissions:
   contents: read
   pull-requests: write
 on: pull_request
+env: 
+  WORKSPACE: "$(git rev-parse --show-toplevel)"
 
 jobs:
   lint:
@@ -56,7 +58,7 @@ jobs:
           kubectl --namespace aerospike create secret generic aerospike-secret \
           --from-literal=features.conf="$(echo "${{ secrets.FEATURES_CONF }}")"
           
-          kubectl apply -f ci/aerospike.yaml --wait
+          kubectl apply -f ${{env.WORKSPACE}}/ci/aerospike.yaml --wait
 
       - name: Setup avs prerequisites
         run: |
@@ -66,7 +68,7 @@ jobs:
                           --for=condition=ready pod \
                           --selector=app=metallb \
                           --timeout=90s
-          kubectl apply -f "charts/aerospike-vector-search/kind/config/metallb-config.yaml"
+          kubectl apply -f "${{env.WORKSPACE}}/examples/kind/config/metallb-config.yaml"
 
 
           echo "Deploying Istio"
@@ -75,16 +77,15 @@ jobs:
           helm install istio-base istio/base --namespace istio-system --set defaultRevision=default --create-namespace --wait
           helm install istiod istio/istiod --namespace istio-system --create-namespace --wait
           helm install istio-ingress istio/gateway \
-          --values "charts/aerospike-vector-search/kind/config/istio-ingressgateway-values.yaml" \
+          --values "${{env.WORKSPACE}}/examples/kind/config/istio-ingressgateway-values.yaml" \
           --namespace istio-ingress \
           --create-namespace \
           --wait
 
-          kubectl apply -f "charts/aerospike-vector-search/kind/config/gateway.yaml" --wait
-          kubectl apply -f "charts/aerospike-vector-search/kind/config/virtual-service-vector-search.yaml" --wait
+          kubectl apply -f "${{env.WORKSPACE}}/examples/kind/config/gateway.yaml" --wait
+          kubectl apply -f "${{env.WORKSPACE}}/examples/kind/config/virtual-service-vector-search.yaml" --wait
 
       - name: Run chart-testing (install)
         run: |
-          cd chart/aerospike-vector-search
           ct install --namespace aerospike  \
             --target-branch ${{ github.event.repository.default_branch }} 

--- a/charts/aerospike-vector-search/ci/avs-kind-values.yaml
+++ b/charts/aerospike-vector-search/ci/avs-kind-values.yaml
@@ -1,7 +1,7 @@
 aerospikeVectorSearchConfig:
   cluster:
     cluster-name: "avs-db-1"
-  feature-key-file: "/etc/aerospike-vector-search/features.conf"
+  feature-key-file: "/etc/aerospike/secret/features.conf" # Sharing secret with aerospike.
   service:
     ports:
       5000:

--- a/charts/aerospike-vector-search/ci/avs-kind-values.yaml
+++ b/charts/aerospike-vector-search/ci/avs-kind-values.yaml
@@ -1,7 +1,7 @@
 aerospikeVectorSearchConfig:
   cluster:
     cluster-name: "avs-db-1"
-  feature-key-file: "/etc/aerospike/secret/features.conf"  # Sharing secret with aerospike.
+  feature-key-file: "/etc/aerospike-vector-search/secrets/features.conf"  # Sharing secret with aerospike.
   service:
     ports:
       5000:

--- a/charts/aerospike-vector-search/ci/avs-kind-values.yaml
+++ b/charts/aerospike-vector-search/ci/avs-kind-values.yaml
@@ -1,7 +1,7 @@
 aerospikeVectorSearchConfig:
   cluster:
     cluster-name: "avs-db-1"
-  feature-key-file: "/etc/aerospike/secret/features.conf" # Sharing secret with aerospike.
+  feature-key-file: "/etc/aerospike/secret/features.conf"  # Sharing secret with aerospike.
   service:
     ports:
       5000:

--- a/charts/aerospike-vector-search/ci/avs-kind-values.yaml
+++ b/charts/aerospike-vector-search/ci/avs-kind-values.yaml
@@ -9,7 +9,7 @@ aerospikeVectorSearchConfig:
           "0.0.0.0"
   manage:
     ports:
-      5040: { }
+      5040: {}
   interconnect:
     ports:
       5001:

--- a/charts/aerospike-vector-search/ci/avs-kind-values.yaml
+++ b/charts/aerospike-vector-search/ci/avs-kind-values.yaml
@@ -1,0 +1,42 @@
+aerospikeVectorSearchConfig:
+  cluster:
+    cluster-name: "avs-db-1"
+  feature-key-file: "/etc/aerospike-vector-search/features.conf"
+  service:
+    ports:
+      5000:
+        addresses:
+          "0.0.0.0"
+  manage:
+    ports:
+      5040: { }
+  interconnect:
+    ports:
+      5001:
+        addresses:
+          "0.0.0.0"
+  aerospike:
+    seeds:
+      - aerospike-cluster-0-0.aerospike-cluster.aerospike.svc.cluster.local:
+          port: 3000
+  logging:
+    #    file: /var/log/aerospike-vector-search/aerospike-vector-search.log
+    enable-console-logging: false
+    format: simple
+    max-history: 30
+    levels:
+      metrics-ticker: info
+      root: info
+    ticker-interval: 10
+
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsUser: 0
+
+service:
+  enabled: false
+  type: ClusterIP
+  ports:
+    - name: "svc-port"
+      port: 5000
+      targetPort: 5000

--- a/ci/aerospike.yaml
+++ b/ci/aerospike.yaml
@@ -1,0 +1,104 @@
+  apiVersion: asdb.aerospike.com/v1
+  kind: AerospikeCluster
+  metadata:
+    name: aerospike-cluster
+    namespace: aerospike
+  spec:
+    size: 1
+    image: aerospike/aerospike-server-enterprise:7.0.0.5
+    podSpec:
+      multiPodPerHost: true
+    storage:
+      filesystemVolumePolicy:
+        cascadeDelete: true
+        initMethod: deleteFiles
+      volumes:
+        - name: workdir
+          source:
+            persistentVolume:
+              storageClass: standard
+              volumeMode: Filesystem
+              size: 3Gi
+          aerospike:
+            path: /opt/aerospike
+        - name: nsvol1
+          aerospike:
+            path: /mnt/disks/test
+          source:
+            persistentVolume:
+              storageClass: standard
+              volumeMode: Filesystem
+              size: 16G
+        - name: nsvol2
+          aerospike:
+            path: /mnt/disks/avs-index
+          source:
+            persistentVolume:
+              storageClass: standard
+              volumeMode: Filesystem
+              size: 16G
+        - name: nsvol3
+          aerospike:
+            path: /mnt/disks/avs-data
+          source:
+            persistentVolume:
+              storageClass: standard
+              volumeMode: Filesystem
+              size: 16G
+        - name: nsvol4
+          aerospike:
+            path: /mnt/disks/avs-meta
+          source:
+            persistentVolume:
+              storageClass: standard
+              volumeMode: Filesystem
+              size: 16G
+        - name: aerospike-config-secret
+          source:
+            secret:
+              secretName: aerospike-secret
+          aerospike:
+            path: /etc/aerospike/secret
+    aerospikeConfig:
+      service:
+        feature-key-file: /etc/aerospike/secret/features.conf
+      #    security: {}
+      network:
+        service:
+          port: 3000
+        fabric:
+          port: 3001
+        heartbeat:
+          port: 3002
+      namespaces:
+        - name: test
+          replication-factor: 2
+          storage-engine:
+            type: device
+            filesize: 17179869184
+            files:
+              - /mnt/disks/test/test.dat
+        - name: avs-index
+          replication-factor: 2
+          storage-engine:
+            type: device
+            filesize: 17179869184
+            files:
+              - /mnt/disks/avs-index/avs-index.dat
+        - name: avs-data
+          replication-factor: 2
+          storage-engine:
+            type: device
+            filesize: 17179869184
+            files:
+              - /mnt/disks/avs-data/avs-data.dat
+        - name: avs-meta
+          nsup-period: 600
+          nsup-threads: 2
+          evict-tenths-pct: 5
+          replication-factor: 2
+          storage-engine:
+            type: device
+            filesize: 17179869184
+            files:
+              - /mnt/disks/avs-meta/avs-meta.dat

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,2 +1,2 @@
 chart-dirs:
-  - chart
+  - charts


### PR DESCRIPTION
Adds test action to charts. Includes values for the chart as well as config for aerospike.

Currently spins up an aerospike cluster in kind, deploys the chart which spins up an avs cluster, and then runs the tests on it (currently just one basic test).